### PR TITLE
Fix: Force mobile menu visibility toggle with !important

### DIFF
--- a/style.css
+++ b/style.css
@@ -570,12 +570,12 @@ footer .copyright p {
     header nav ul#main-menu { /* Targeting #main-menu specifically */
         flex-direction: column;
         width: 100%;
-        display: none; /* Hidden by default, toggled by JS */
+        display: none !important; /* Hidden by default, toggled by JS - FORCED HIDDEN */
         margin-top: 10px;
     }
 
     header nav ul#main-menu.active { /* Targeting #main-menu.active specifically */
-        display: flex;
+        display: flex !important; /* Ensure this overrides the display:none !important */
     }
 
     header nav ul li {


### PR DESCRIPTION
Applied `!important` to `display: none` for the default hidden state of the mobile menu and `display: flex` for its `.active` (visible) state.

This is to ensure the menu correctly hides by default and toggles visibility, overriding any stubborn CSS rules that were preventing the previous attempts from working as observed on the live site.