### PR TITLE
Feat: Integrate 'Get Started' button into mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,8 @@
                 <li><a href="ngo-matchmaking.html">NGO Matchmaking</a></li>
                 <li><a href="#faq-on-index">FAQs</a></li>
                 <li><a href="#contact">Contact Us</a></li>
+                <li class="menu-cta-button-item"><a href="#ready-to-join" class="button">Get Started</a></li>
             </ul>
-            <div class="cta-nav">
-                <a href="#ready-to-join" class="button">Get Started</a>
-            </div>
         </nav>
     </header>
 

--- a/ngo-matchmaking.html
+++ b/ngo-matchmaking.html
@@ -20,10 +20,8 @@
                 <li><a href="ngo-matchmaking.html" class="active">NGO Matchmaking</a></li>
                 <li><a href="/#faq-on-index">FAQs</a></li>
                 <li><a href="/#contact">Contact Us</a></li>
+                <li class="menu-cta-button-item"><a href="/#ready-to-join" class="button">Get Started</a></li>
             </ul>
-            <div class="cta-nav">
-                <a href="/#ready-to-join" class="button">Get Started</a>
-            </div>
         </nav>
     </header>
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -20,10 +20,8 @@
                 <li><a href="ngo-matchmaking.html">NGO Matchmaking</a></li>
                 <li><a href="/#faq-on-index">FAQs</a></li>
                 <li><a href="/#contact">Contact Us</a></li>
+                <li class="menu-cta-button-item"><a href="/#ready-to-join" class="button">Get Started</a></li>
             </ul>
-            <div class="cta-nav">
-                <a href="/#ready-to-join" class="button">Get Started</a>
-            </div>
         </nav>
     </header>
 

--- a/style.css
+++ b/style.css
@@ -180,6 +180,19 @@ header .cta-nav .button {
     font-size: 0.9rem;
 }
 
+/* Style for the CTA button when it's part of the main menu list on desktop */
+header nav ul li.menu-cta-button-item {
+    margin-left: auto; /* Push this item to the far right */
+    padding-left: 20px; /* Add some space from the preceding nav item if any, or use margin-left on .button itself */
+}
+header nav ul li.menu-cta-button-item a.button {
+    /* Desktop specific styles for the button if needed, e.g., vertical alignment.
+       The .button class already provides most styling.
+       The `align-items: center;` on the parent `ul` should handle vertical alignment.
+    */
+}
+
+
 /* Mobile Menu Styles (Placeholder for JS interaction) */
 .menu-toggle {
     display: none; /* Hidden by default, shown on mobile */
@@ -590,6 +603,17 @@ footer .copyright p {
     }
     header nav ul li a::after { /* Disable underline effect on mobile for cleaner look */
         display: none;
+    }
+
+    /* Ensure the CTA button item in menu also behaves well on mobile */
+    header nav ul li.menu-cta-button-item {
+        padding: 10px 0; /* Add some padding around the button */
+        text-align: center; /* Center the button if it's not full width */
+    }
+    header nav ul li.menu-cta-button-item a.button {
+        display: inline-block; /* Ensure button class takes effect */
+        width: auto; /* Allow button to size to its content or a set width */
+        /* Potentially make it full width if desired: width: 90%; margin: 0 auto; */
     }
 
 

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -20,10 +20,8 @@
                 <li><a href="ngo-matchmaking.html">NGO Matchmaking</a></li>
                 <li><a href="/#faq-on-index">FAQs</a></li>
                 <li><a href="/#contact">Contact Us</a></li>
+                <li class="menu-cta-button-item"><a href="/#ready-to-join" class="button">Get Started</a></li>
             </ul>
-            <div class="cta-nav">
-                <a href="/#ready-to-join" class="button">Get Started</a>
-            </div>
         </nav>
     </header>
 


### PR DESCRIPTION
- Moved the 'Get Started' button into the main navigation list (`ul#main-menu`) in all HTML files to make it part of the toggleable mobile menu.
- Adjusted CSS for mobile view to style the button item within the expanded menu.
- Adjusted CSS for desktop view to ensure the button remains visible and is positioned to the far right of the navigation links using `margin-left: auto;`.

This change makes the 'Get Started' button hidden by default on mobile unless the menu is expanded, as per user request.