### PR TITLE
Fix: Correct footer quick links on sub-pages to prevent 404s

### DIFF
--- a/ngo-matchmaking.html
+++ b/ngo-matchmaking.html
@@ -102,7 +102,7 @@
                 <ul>
                     <li><a href="/#pilot">Pilot Program</a></li>
                     <li><a href="/#solution">Our Solution</a></li>
-                    <li><a href="faq.html">FAQs</a></li>
+                    <li><a href="/#faq-on-index">FAQs</a></li>
                     <li><a href="ngo-matchmaking.html">NGO Matchmaking Tool</a></li>
                 </ul>
             </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -172,7 +172,7 @@
                 <ul>
                     <li><a href="/#pilot">Pilot Program</a></li>
                     <li><a href="/#solution">Our Solution</a></li>
-                    <li><a href="faq.html">FAQs</a></li>
+                    <li><a href="/#faq-on-index">FAQs</a></li>
                     <li><a href="ngo-matchmaking.html">NGO Matchmaking Tool</a></li>
                 </ul>
             </div>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -99,7 +99,7 @@
                 <ul>
                     <li><a href="/#pilot">Pilot Program</a></li>
                     <li><a href="/#solution">Our Solution</a></li>
-                    <li><a href="faq.html">FAQs</a></li>
+                    <li><a href="/#faq-on-index">FAQs</a></li>
                     <li><a href="ngo-matchmaking.html">NGO Matchmaking Tool</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
Updated the 'Quick Links' in the footers of `ngo-matchmaking.html`, `terms-of-use.html`, and `privacy-policy.html`. Specifically, the 'FAQs' link was changed from `faq.html` to `/#faq-on-index`. The links for 'Pilot Program' and 'Our Solution' were verified to be already using correct root-relative paths (e.g., `/#pilot`).

This ensures these links correctly navigate to the respective sections on `index.html` when clicked from sub-pages, resolving the GitHub Pages 404 errors previously encountered.