### PR TITLE
Fix: Use explicit index.html#section links from sub-pages

### DIFF
--- a/ngo-matchmaking.html
+++ b/ngo-matchmaking.html
@@ -15,12 +15,12 @@
             </div>
             <button class="menu-toggle" aria-label="Open Menu" aria-expanded="false">&#9776;</button>
             <ul id="main-menu">
-                <li><a href="/#dashboard-preview">Dashboard</a></li>
-                <li><a href="/#pilot">Pilot Program</a></li>
+                <li><a href="index.html#dashboard-preview">Dashboard</a></li>
+                <li><a href="index.html#pilot">Pilot Program</a></li>
                 <li><a href="ngo-matchmaking.html" class="active">NGO Matchmaking</a></li>
-                <li><a href="/#faq-on-index">FAQs</a></li>
-                <li><a href="/#contact">Contact Us</a></li>
-                <li class="menu-cta-button-item"><a href="/#ready-to-join" class="button">Get Started</a></li>
+                <li><a href="index.html#faq-on-index">FAQs</a></li>
+                <li><a href="index.html#contact">Contact Us</a></li>
+                <li class="menu-cta-button-item"><a href="index.html#ready-to-join" class="button">Get Started</a></li>
             </ul>
         </nav>
     </header>
@@ -85,7 +85,7 @@
                 </div>
                 <div class="cta-bottom">
                     <p>Can't find what you're looking for or want to get listed?</p>
-                    <a href="/#ready-to-join" class="button">Apply as NGO</a>
+                    <a href="index.html#ready-to-join" class="button">Apply as NGO</a> <!-- Also update this link -->
                 </div>
             </div>
         </section>
@@ -100,9 +100,9 @@
             <div>
                 <h4>Quick Links</h4>
                 <ul>
-                    <li><a href="/#pilot">Pilot Program</a></li>
-                    <li><a href="/#solution">Our Solution</a></li>
-                    <li><a href="/#faq-on-index">FAQs</a></li>
+                    <li><a href="index.html#pilot">Pilot Program</a></li>
+                    <li><a href="index.html#solution">Our Solution</a></li>
+                    <li><a href="index.html#faq-on-index">FAQs</a></li>
                     <li><a href="ngo-matchmaking.html">NGO Matchmaking Tool</a></li>
                 </ul>
             </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -15,12 +15,12 @@
             </div>
             <button class="menu-toggle" aria-label="Open Menu" aria-expanded="false">&#9776;</button>
             <ul id="main-menu">
-                <li><a href="/#dashboard-preview">Dashboard</a></li>
-                <li><a href="/#pilot">Pilot Program</a></li>
+                <li><a href="index.html#dashboard-preview">Dashboard</a></li>
+                <li><a href="index.html#pilot">Pilot Program</a></li>
                 <li><a href="ngo-matchmaking.html">NGO Matchmaking</a></li>
-                <li><a href="/#faq-on-index">FAQs</a></li>
-                <li><a href="/#contact">Contact Us</a></li>
-                <li class="menu-cta-button-item"><a href="/#ready-to-join" class="button">Get Started</a></li>
+                <li><a href="index.html#faq-on-index">FAQs</a></li>
+                <li><a href="index.html#contact">Contact Us</a></li>
+                <li class="menu-cta-button-item"><a href="index.html#ready-to-join" class="button">Get Started</a></li>
             </ul>
         </nav>
     </header>
@@ -170,9 +170,9 @@
             <div>
                 <h4>Quick Links</h4>
                 <ul>
-                    <li><a href="/#pilot">Pilot Program</a></li>
-                    <li><a href="/#solution">Our Solution</a></li>
-                    <li><a href="/#faq-on-index">FAQs</a></li>
+                    <li><a href="index.html#pilot">Pilot Program</a></li>
+                    <li><a href="index.html#solution">Our Solution</a></li>
+                    <li><a href="index.html#faq-on-index">FAQs</a></li>
                     <li><a href="ngo-matchmaking.html">NGO Matchmaking Tool</a></li>
                 </ul>
             </div>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -15,12 +15,12 @@
             </div>
             <button class="menu-toggle" aria-label="Open Menu" aria-expanded="false">&#9776;</button>
             <ul id="main-menu">
-                <li><a href="/#dashboard-preview">Dashboard</a></li>
-                <li><a href="/#pilot">Pilot Program</a></li>
+                <li><a href="index.html#dashboard-preview">Dashboard</a></li>
+                <li><a href="index.html#pilot">Pilot Program</a></li>
                 <li><a href="ngo-matchmaking.html">NGO Matchmaking</a></li>
-                <li><a href="/#faq-on-index">FAQs</a></li>
-                <li><a href="/#contact">Contact Us</a></li>
-                <li class="menu-cta-button-item"><a href="/#ready-to-join" class="button">Get Started</a></li>
+                <li><a href="index.html#faq-on-index">FAQs</a></li>
+                <li><a href="index.html#contact">Contact Us</a></li>
+                <li class="menu-cta-button-item"><a href="index.html#ready-to-join" class="button">Get Started</a></li>
             </ul>
         </nav>
     </header>
@@ -97,9 +97,9 @@
             <div>
                 <h4>Quick Links</h4>
                 <ul>
-                    <li><a href="/#pilot">Pilot Program</a></li>
-                    <li><a href="/#solution">Our Solution</a></li>
-                    <li><a href="/#faq-on-index">FAQs</a></li>
+                    <li><a href="index.html#pilot">Pilot Program</a></li>
+                    <li><a href="index.html#solution">Our Solution</a></li>
+                    <li><a href="index.html#faq-on-index">FAQs</a></li>
                     <li><a href="ngo-matchmaking.html">NGO Matchmaking Tool</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
Updated links in header menus and footer quick links on sub-pages (`ngo-matchmaking.html`, `terms-of-use.html`, `privacy-policy.html`) that point to sections on `index.html`.

Changed hrefs from root-relative (e.g., `/#pilot`) to explicit paths (e.g., `index.html#pilot`). This is intended to make the links more robust for GitHub Pages and resolve the '404 - there isn't a GitHub Pages site here' errors previously encountered when navigating from these sub-pages to `index.html` sections.