### PR TITLE
Feat: Update CTA links for Tally form and Calendly

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,13 +241,13 @@
                         <h3>For NGOs</h3>
                         <h4>Get Discovered by CSR Funders</h4>
                         <p>Submit your NGO profile and documents via our quick form. Increase your visibility and connect with corporates looking to fund impactful projects.</p>
-                        <a href="https://example.com/ngo-application-form" class="button">Apply to Join</a>
+                        <a href="https://tally.so/r/w55VWE" class="button" target="_blank">Apply to Join</a>
                     </div>
                     <div class="join-column">
                         <h3>For Corporates</h3>
                         <h4>Let’s Co-Create Impact</h4>
                         <p>Book a quick call to explore CSR collaboration with verified NGOs. Discover how our platform can streamline your CSR initiatives and maximize your social impact.</p>
-                        <a href="https://calendly.com/example" class="button">Schedule a 30-min Call</a>
+                        <a href="https://calendly.com/connect-impactxbridge/30min?month=2025-06" class="button" target="_blank">Schedule a 30-min Call</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Updated the href attributes for the call-to-action buttons in the 'Ready to Join' section of `index.html`:
- The 'Apply to Join' button for NGOs now links to the specified Tally form: https://tally.so/r/w55VWE.
- The 'Schedule a 30-min Call' button for Corporates now links to the specified Calendly page: https://calendly.com/connect-impactxbridge/30min?month=2025-06.

Both links have been set to open in a new tab (`target="_blank"`).