### PR TITLE
Feat: Add full logo to footer with responsive alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,8 +359,7 @@
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
                 <!-- Social media links can go here -->
             </div>
-            <!-- This div will be part of the footer's main grid container -->
-            <div class="footer-logo-container">
+            <div class="footer-logo-item">
                  <img src="/New-ImpactX-/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">
             </div>
             <div class="copyright">

--- a/ngo-matchmaking.html
+++ b/ngo-matchmaking.html
@@ -110,7 +110,7 @@
                 <h4>Connect With Us</h4>
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
             </div>
-            <div class="footer-logo-container">
+            <div class="footer-logo-item">
                  <img src="/New-ImpactX-/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">
             </div>
             <div class="copyright">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -180,7 +180,7 @@
                 <h4>Connect With Us</h4>
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
             </div>
-            <div class="footer-logo-container">
+            <div class="footer-logo-item">
                  <img src="/New-ImpactX-/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">
             </div>
             <div class="copyright">

--- a/style.css
+++ b/style.css
@@ -854,21 +854,24 @@ footer .container {
     /* gap: 20px; is good */
 }
 
-/* Styling for the full logo in the footer */
-.footer-logo-container {
-    grid-column: 1 / -1; /* Span all columns in the footer grid */
-    text-align: center;
-    padding: 20px 0; /* Add some vertical spacing */
+/* Styling for the full logo in the footer (new class: footer-logo-item) */
+.footer-logo-item {
+    grid-column: 1 / -1; /* Span all columns in the footer grid, making it a new row */
+    text-align: right; /* Align image to the right by default (for desktop) */
+    padding: 20px 0;
 }
 
 .footer-full-logo-img {
     max-width: 220px; /* Default max-width for larger screens */
     height: auto;   /* Maintain aspect ratio */
-    display: inline-block; /* Allows text-align:center to work if not already block */
+    display: inline-block;
 }
 
-/* Responsive adjustments for footer logo if needed */
+/* Responsive adjustments for footer logo */
 @media (max-width: 768px) {
+    .footer-logo-item {
+        text-align: center; /* Center logo on smaller screens */
+    }
     .footer-full-logo-img {
         max-width: 180px; /* Slightly smaller on tablets/mobile */
     }
@@ -883,7 +886,7 @@ footer .container {
 footer .copyright {
     grid-column: 1 / -1; /* Correct for grid */
     text-align: center;
-    margin-top: 30px;
+    margin-top: 30px; /* Copyright margin might need adjustment if logo is directly above */
     padding-top: 20px;
     border-top: 1px solid #4a4e69;
 }

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -107,7 +107,7 @@
                 <h4>Connect With Us</h4>
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
             </div>
-            <div class="footer-logo-container">
+            <div class="footer-logo-item">
                  <img src="/New-ImpactX-/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">
             </div>
             <div class="copyright">


### PR DESCRIPTION
- Added `logowithname.png` to the footer of all HTML pages.
- The logo is placed in its own full-width row below the main footer content (Quick Links, Connect With Us) and above the copyright.
- CSS ensures the logo is right-aligned within this row on desktop screens and center-aligned on tablet/mobile screens (<= 768px).
- Responsive sizing for the logo image is maintained (max-width: 220px desktop, 180px tablet, 150px mobile).