### PR TITLE
Refactor: Footer logo as 4th column on desktop, stacks on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -852,12 +852,28 @@ footer .container {
     /* display: grid; is good */
     /* grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); is good */
     /* gap: 20px; is good */
+    align-items: start; /* Align items to the start of their grid area */
 }
+
+@media (min-width: 992px) {
+    footer .container {
+        grid-template-columns: 1.5fr 1.5fr 1.5fr 1fr; /* 3 content columns, 1 logo column */
+    }
+}
+/* Make .footer-logo-item a flex container for alignment on desktop */
+@media (min-width: 769px) { /* Apply from tablet upwards for better control */
+    .footer-logo-item {
+        display: flex;
+        justify-content: flex-end; /* Align logo to the right within its cell */
+        align-items: center; /* Vertically center logo in its cell */
+    }
+}
+
 
 /* Styling for the full logo in the footer (new class: footer-logo-item) */
 .footer-logo-item {
-    grid-column: 1 / -1; /* Span all columns in the footer grid, making it a new row */
-    text-align: right; /* Align image to the right by default (for desktop) */
+    /* grid-column: 1 / -1; /* REMOVED - it's now a standard grid item */
+    text-align: center; /* Default to center for mobile when it stacks */
     padding: 20px 0;
 }
 


### PR DESCRIPTION
- Modified footer HTML to ensure the logo container (`.footer-logo-item`) is a direct child of the main footer grid container.
- Updated CSS for `footer .container`:
  - On desktop (>=992px), uses `grid-template-columns: 1.5fr 1.5fr 1.5fr 1fr;` to create a 4-column layout.
  - Default `auto-fit` grid allows stacking on smaller screens.
- Updated CSS for `.footer-logo-item`:
  - On desktop/tablet (>=769px), uses flexbox to align the logo image to the right and center it vertically within its grid cell.
  - On mobile (<769px), uses `text-align: center;` to center the logo when it stacks.
- Responsive sizing for the logo image itself is maintained.