### PR TITLE
Style: Change hero paragraph text to blue with enhanced shadow

### DIFF
--- a/style.css
+++ b/style.css
@@ -298,8 +298,8 @@ footer .copyright p {
 }
 
 #hero p {
-    color: #f0f0f0; /* Changed to light gray/off-white for better contrast */
-    text-shadow: 1px 1px 2px rgba(0,0,0,0.5); /* Added subtle shadow for readability */
+    color: #007bff; /* Changed to primary blue as requested */
+    text-shadow: 0 1px 1px rgba(0,0,0,0.4), 0 0 5px rgba(255,255,255,0.3); /* Composite shadow for readability */
     font-size: 1.1rem;
     margin-bottom: 30px;
     max-width: 700px;


### PR DESCRIPTION
- Updated the CSS for `#hero p`.
- Changed text `color` to `#007bff` (primary blue).
- Applied a composite `text-shadow` (0 1px 1px rgba(0,0,0,0.4), 0 0 5px rgba(255,255,255,0.3);) to improve readability against the varied colors of the hero banner background.