### PR TITLE
Style: Change hero paragraph text to green with outline

### DIFF
--- a/style.css
+++ b/style.css
@@ -298,8 +298,8 @@ footer .copyright p {
 }
 
 #hero p {
-    color: #007bff; /* Changed to primary blue as requested */
-    text-shadow: 0 1px 1px rgba(0,0,0,0.4), 0 0 5px rgba(255,255,255,0.3); /* Composite shadow for readability */
+    color: #28a745; /* Changed to green */
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000, 1px 1px 2px rgba(0,0,0,0.7); /* Black outline and slight shadow */
     font-size: 1.1rem;
     margin-bottom: 30px;
     max-width: 700px;


### PR DESCRIPTION
- Updated the CSS for `#hero p`.
- Changed text `color` to `#28a745` (green).
- Applied a `text-shadow` that creates a 1px black outline effect plus a slight additional shadow, to improve readability against the varied colors of the hero banner background.