### PR TITLE
Fix: Center social media icons in footer on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -818,7 +818,8 @@ section:not(#hero) .container { /* Apply to sections that need centered content 
         grid-column: 1 / -1; /* Full width on mobile */
     }
     .social-media-links { /* Ensure icons center or align left on mobile if they wrap */
-        justify-content: center; /* Or flex-start if preferred */
+        width: 100%; /* Ensure the container takes full width for centering to be effective */
+        justify-content: center;
     }
 }
 


### PR DESCRIPTION
Updated the CSS for `.social-media-links` within the mobile media query (`max-width: 768px`).
Added `width: 100%;` to ensure the container spans the full available width, allowing `justify-content: center;` (which was already present) to effectively center the icons on mobile devices.