### PR TITLE
Fix: Update header logo link for GitHub Pages compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <header>
         <nav> <!-- This nav is the direct child of header, acts as a container -->
             <div class="logo">
-                <a href="/"><img src="/New-ImpactX-/logo.png" alt="ImpactX Bridge Logo" class="header-logo-img"> ImpactX Bridge</a>
+                <a href="/New-ImpactX-/"><img src="/New-ImpactX-/logo.png" alt="ImpactX Bridge Logo" class="header-logo-img"> ImpactX Bridge</a>
             </div>
             <button class="menu-toggle" aria-label="Open Menu" aria-expanded="false">&#9776;</button>
             <ul id="main-menu">

--- a/ngo-matchmaking.html
+++ b/ngo-matchmaking.html
@@ -12,7 +12,7 @@
     <header>
         <nav>
             <div class="logo">
-                <a href="/"><img src="/New-ImpactX-/logo.png" alt="ImpactX Bridge Logo" class="header-logo-img"> ImpactX Bridge</a>
+                <a href="/New-ImpactX-/"><img src="/New-ImpactX-/logo.png" alt="ImpactX Bridge Logo" class="header-logo-img"> ImpactX Bridge</a>
             </div>
             <button class="menu-toggle" aria-label="Open Menu" aria-expanded="false">&#9776;</button>
             <ul id="main-menu">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -12,7 +12,7 @@
     <header>
         <nav>
             <div class="logo">
-                <a href="/"><img src="/New-ImpactX-/logo.png" alt="ImpactX Bridge Logo" class="header-logo-img"> ImpactX Bridge</a>
+                <a href="/New-ImpactX-/"><img src="/New-ImpactX-/logo.png" alt="ImpactX Bridge Logo" class="header-logo-img"> ImpactX Bridge</a>
             </div>
             <button class="menu-toggle" aria-label="Open Menu" aria-expanded="false">&#9776;</button>
             <ul id="main-menu">

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -12,7 +12,7 @@
     <header>
         <nav>
             <div class="logo">
-                <a href="/"><img src="/New-ImpactX-/logo.png" alt="ImpactX Bridge Logo" class="header-logo-img"> ImpactX Bridge</a>
+                <a href="/New-ImpactX-/"><img src="/New-ImpactX-/logo.png" alt="ImpactX Bridge Logo" class="header-logo-img"> ImpactX Bridge</a>
             </div>
             <button class="menu-toggle" aria-label="Open Menu" aria-expanded="false">&#9776;</button>
             <ul id="main-menu">


### PR DESCRIPTION
Changed the `href` attribute for the main header logo link from `/` to `/New-ImpactX-/` in all HTML files.

This ensures the logo correctly links to the `index.html` of the project when deployed on GitHub Pages (e.g., `username.github.io/New-ImpactX-/`), resolving previous 404 errors.