### PR TITLE
Style: Reduce size of founder profile pictures

### DIFF
--- a/style.css
+++ b/style.css
@@ -922,8 +922,8 @@ section:not(#hero) .container { /* Apply to sections that need centered content 
 }
 
 .founder-profile-pic {
-    width: 130px;
-    height: 130px;
+    width: 60px;
+    height: 60px;
     border-radius: 50%; /* Circular profile pictures */
     object-fit: cover; /* Ensure image covers the area well, might crop if not square */
     margin-bottom: 15px;


### PR DESCRIPTION
Changed the width and height of the `.founder-profile-pic` class from 130px to 60px in `style.css` to make the images on the 'About Us' page more compact.