### PR TITLE
Fix: Correct multiple H1 tags on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,7 +324,7 @@
 
     <section id="faq-on-index">
         <div class="container">
-            <h1>Frequently Asked Questions</h1>
+            <h2>Frequently Asked Questions</h2>
 
             <div class="faq-item">
                 <button class="faq-question" aria-expanded="false">Who can join the pilot?</button>


### PR DESCRIPTION
Changed the secondary H1 tag for the FAQ section to H2 to ensure proper heading hierarchy on index.html.