### PR TITLE
Fix: Correct icon display and update text color on About Us page

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -92,9 +92,9 @@
         <section id="about-us-content">
             <div class="container">
                 <h1>About Us</h1>
-                <p class="tagline" style="text-align: center; font-size: 1.3em; margin-bottom: 2em;">🧱 Built from the Ground, for the Ground</p>
+                <p class="tagline" style="text-align: center; font-size: 1.3em; margin-bottom: 2em;"><i class="fas fa-layer-group"></i> Built from the Ground, for the Ground</p>
 
-                <h2>🏛 About ImpactX Bridge</h2>
+                <h2><i class="fas fa-landmark"></i> About ImpactX Bridge</h2>
                 <p>ImpactX Bridge is part of ImpactX — a platform reimagining how social good gets funded in India.</p>
                 <p>We help CSR teams connect with verified grassroots NGOs through a digital system built on trust, transparency, and speed. From intelligent matching to audit-ready reports, we’re creating the infrastructure that moves CSR from paperwork… to real-world progress.</p>
 

--- a/style.css
+++ b/style.css
@@ -1070,7 +1070,7 @@ section:not(#hero) .container { /* Apply to sections that need centered content 
 
 .founder-profile h3 {
     margin-bottom: 0.3em;
-    color: #1a237e; /* Match other h3s */
+    color: #212121;       /* CHANGED to #212121 (black) */
 }
 
 .founder-profile p {
@@ -1104,6 +1104,12 @@ section:not(#hero) .container { /* Apply to sections that need centered content 
 #about-us-content blockquote { /* Ensure blockquote styling is consistent */
     margin-top: 1.5em;
     font-size: 1.1em;
+}
+
+/* About Us Page - Icon Spacing */
+#about-us-content .tagline i.fas,
+#about-us-content h2 i.fas {
+    margin-right: 0.5em; /* Space between icon and text */
 }
 
 


### PR DESCRIPTION
- Replaced Unicode emojis (which were rendering as blocks) in the tagline and 'About ImpactX Bridge' heading on `about-us.html` with Font Awesome icons (`fas fa-layer-group` and `fas fa-landmark` respectively).
- Added CSS in `style.css` to provide appropriate spacing for these new icons.
- Changed the text color of founder names (`.founder-profile h3`) from blue to black (`#212121`) for consistency with other headings, assuming this preference.

Note: No changes were made to address founder image clarity, as this is likely an issue with the source image files rather than CSS.