### PR TITLE
Fix: Center footer social media icons on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -968,7 +968,7 @@ section:not(#hero) .container { /* Apply to sections that need centered content 
     }
     /* Footer columns on mobile */
     footer div {
-        /* text-align: center; /* Removed, as child flex container will handle its own alignment */
+        text-align: center; /* Ensure text-based content within footer divs is centered on mobile */
     }
     .social-media-links {
         display: flex; /* Ensure it's a flex container */


### PR DESCRIPTION
Updated CSS to ensure footer social media icons are center-aligned on mobile devices. Added text-align: center to the parent footer div in the mobile media query to support the existing flex centering on the social-media-links container.