### PR TITLE
Fix: Force flex display for dashboard chart previews

### DIFF
--- a/style.css
+++ b/style.css
@@ -1493,3 +1493,10 @@ section {
         flex-basis: auto; /* Reset flex-basis for stacked layout */
     }
 }
+
+/* Ensure flex display for dashboard preview specifically, in case of conflict */
+/* This generally shouldn't be needed if specificity is managed well, but as a targeted fix: */
+#dashboard-preview .chart-preview-images {
+    display: flex; /* Re-asserting display flex */
+    /* Other properties like gap, justify-content should be inherited from the general .chart-preview-images rule */
+}


### PR DESCRIPTION
Added a more specific CSS rule for .chart-preview-images within the #dashboard-preview section to ensure 'display: flex' is applied, addressing an issue where images were not appearing side-by-side.