### PR TITLE
Refactor: Remove chart preview images from dashboard section

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,10 +206,7 @@
                 <h2>Dashboard</h2>
                 <!-- Placeholder for dashboard visual representation -->
                 <p><em>A visual mock-up of the dashboard would appear here, showcasing features like Project Status, Funding by Cause, Impact Over Time, and NGO Activities.</em></p>
-                <div class="chart-preview-images">
-                    <img src="/dashboard.jpg" alt="Chart preview illustrating general CSR trends in India on the ImpactX Bridge dashboard.">
-                    <img src="/dashboard1.jpg" alt="Additional chart preview from the ImpactX Bridge dashboard showcasing CSR data in India.">
-                </div>
+                <!-- Chart preview images removed as per user request -->
             </div>
         </section>
 


### PR DESCRIPTION
Removed the dashboard chart preview images from index.html as they were not displaying side-by-side as intended. This simplifies the section for now.