### PR TITLE
Fix: Re-add dashboard chart preview images

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,10 @@
                 <h2>Dashboard</h2>
                 <!-- Placeholder for dashboard visual representation -->
                 <p><em>A visual mock-up of the dashboard would appear here, showcasing features like Project Status, Funding by Cause, Impact Over Time, and NGO Activities.</em></p>
-                <!-- Chart preview images removed as per user request -->
+                <div class="chart-preview-images">
+                    <img src="/dashboard.jpg" alt="Chart preview illustrating general CSR trends in India on the ImpactX Bridge dashboard.">
+                    <img src="/dashboard1.jpg" alt="Additional chart preview from the ImpactX Bridge dashboard showcasing CSR data in India.">
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
Re-inserted the HTML structure for dashboard chart preview images in index.html, using the .chart-preview-images class, in an attempt to get them to display side-by-side as intended.