### PR TITLE
Refactor: Temporarily remove chart preview images from all sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,10 +206,7 @@
                 <h2>Dashboard</h2>
                 <!-- Placeholder for dashboard visual representation -->
                 <p><em>A visual mock-up of the dashboard would appear here, showcasing features like Project Status, Funding by Cause, Impact Over Time, and NGO Activities.</em></p>
-                <div class="chart-preview-images">
-                    <img src="/dashboard.jpg" alt="Chart preview illustrating general CSR trends in India on the ImpactX Bridge dashboard.">
-                    <img src="/dashboard1.jpg" alt="Additional chart preview from the ImpactX Bridge dashboard showcasing CSR data in India.">
-                </div>
+                <!-- Chart preview images removed -->
             </div>
         </section>
 

--- a/ngo-matchmaking.html
+++ b/ngo-matchmaking.html
@@ -99,10 +99,7 @@
 
                 <div id="future-charts-placeholder" class="charts-area-pending">
                     <p><em>[Future charts showcasing platform impact, such as funding distributions by cause, trends over time, and number of partnerships, will be displayed here. This section will provide a visual overview of our collective achievements.]</em></p>
-                    <div class="chart-preview-images">
-                        <img src="/csrngo.jpg" alt="Chart preview from the ImpactX Bridge CSR-NGO tool highlighting impact made.">
-                        <img src="/csrngo1.jpg" alt="Additional chart preview demonstrating impact achieved through the ImpactX Bridge CSR-NGO matchmaking tool.">
-                    </div>
+                    <!-- Chart preview images removed -->
                 </div>
 
                 <section id="matched-activity-section" class="matched-activity-mvp">


### PR DESCRIPTION
Removed chart preview images from both the dashboard (index.html) and the NGO matchmaking page (ngo-matchmaking.html) to reset the state before attempting to re-add them with correct side-by-side layout.