### PR TITLE
Fix: Re-add footer social media icons and ensure mobile centering

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -162,7 +162,6 @@
             <div>
                 <h4>Connect With Us</h4>
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
-                <!--
                 <div class="social-media-links">
                     <a href="https://x.com/Impactxbridge?t=EETvpqVunYCsPpA_i9TeHA&s=09" target="_blank" aria-label="ImpactX Bridge on X (Twitter)"><i class="fab fa-twitter"></i></a>
                     <a href="https://www.linkedin.com/company/impactxbridge/" target="_blank" aria-label="ImpactX Bridge on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
@@ -170,7 +169,6 @@
                     <a href="https://www.facebook.com/share/1XefZhW6ML/" target="_blank" aria-label="ImpactX Bridge on Facebook"><i class="fab fa-facebook-f"></i></a>
                     <a href="https://youtube.com/@impactxbridge?si=-VhFO5plG41Tcmoe" target="_blank" aria-label="ImpactX Bridge on YouTube"><i class="fab fa-youtube"></i></a>
                 </div>
-                -->
             </div>
             <div class="footer-logo-item">
                  <img src="/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">

--- a/index.html
+++ b/index.html
@@ -464,7 +464,6 @@
             <div>
                 <h4>Connect With Us</h4>
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
-                <!--
                 <div class="social-media-links">
                     <a href="https://x.com/Impactxbridge?t=EETvpqVunYCsPpA_i9TeHA&s=09" target="_blank" aria-label="ImpactX Bridge on X (Twitter)"><i class="fab fa-twitter"></i></a>
                     <a href="https://www.linkedin.com/company/impactxbridge/" target="_blank" aria-label="ImpactX Bridge on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
@@ -472,7 +471,6 @@
                     <a href="https://www.facebook.com/share/1XefZhW6ML/" target="_blank" aria-label="ImpactX Bridge on Facebook"><i class="fab fa-facebook-f"></i></a>
                     <a href="https://youtube.com/@impactxbridge?si=-VhFO5plG41Tcmoe" target="_blank" aria-label="ImpactX Bridge on YouTube"><i class="fab fa-youtube"></i></a>
                 </div>
-                -->
             </div>
             <div class="footer-logo-item">
                  <img src="/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">

--- a/ngo-matchmaking.html
+++ b/ngo-matchmaking.html
@@ -229,7 +229,6 @@
             <div>
                 <h4>Connect With Us</h4>
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
-                <!--
                 <div class="social-media-links">
                     <a href="https://x.com/Impactxbridge?t=EETvpqVunYCsPpA_i9TeHA&s=09" target="_blank" aria-label="ImpactX Bridge on X (Twitter)"><i class="fab fa-twitter"></i></a>
                     <a href="https://www.linkedin.com/company/impactxbridge/" target="_blank" aria-label="ImpactX Bridge on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
@@ -237,7 +236,6 @@
                     <a href="https://www.facebook.com/share/1XefZhW6ML/" target="_blank" aria-label="ImpactX Bridge on Facebook"><i class="fab fa-facebook-f"></i></a>
                     <a href="https://youtube.com/@impactxbridge?si=-VhFO5plG41Tcmoe" target="_blank" aria-label="ImpactX Bridge on YouTube"><i class="fab fa-youtube"></i></a>
                 </div>
-                -->
             </div>
             <div class="footer-logo-item">
                  <img src="/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -203,7 +203,6 @@
             <div>
                 <h4>Connect With Us</h4>
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
-                <!--
                 <div class="social-media-links">
                     <a href="https://x.com/Impactxbridge?t=EETvpqVunYCsPpA_i9TeHA&s=09" target="_blank" aria-label="ImpactX Bridge on X (Twitter)"><i class="fab fa-twitter"></i></a>
                     <a href="https://www.linkedin.com/company/impactxbridge/" target="_blank" aria-label="ImpactX Bridge on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
@@ -211,7 +210,6 @@
                     <a href="https://www.facebook.com/share/1XefZhW6ML/" target="_blank" aria-label="ImpactX Bridge on Facebook"><i class="fab fa-facebook-f"></i></a>
                     <a href="https://youtube.com/@impactxbridge?si=-VhFO5plG41Tcmoe" target="_blank" aria-label="ImpactX Bridge on YouTube"><i class="fab fa-youtube"></i></a>
                 </div>
-                -->
             </div>
             <div class="footer-logo-item">
                  <img src="/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">

--- a/style.css
+++ b/style.css
@@ -1468,7 +1468,7 @@ section {
 
 /* Chart Preview Images Layout */
 .chart-preview-images {
-    display: flex !important; /* Added !important for diagnostics */
+    display: flex; /* Removed !important, syntax error fixed */
     flex-wrap: wrap; /* Allow wrapping on smaller screens if needed, though stacking is preferred */
     justify-content: space-around; /* Distribute space around images */
     gap: 20px; /* Space between images */

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -130,7 +130,6 @@
             <div>
                 <h4>Connect With Us</h4>
                 <p><a href="mailto:connect@impactxbridge.com">connect@impactxbridge.com</a></p>
-                <!--
                 <div class="social-media-links">
                     <a href="https://x.com/Impactxbridge?t=EETvpqVunYCsPpA_i9TeHA&s=09" target="_blank" aria-label="ImpactX Bridge on X (Twitter)"><i class="fab fa-twitter"></i></a>
                     <a href="https://www.linkedin.com/company/impactxbridge/" target="_blank" aria-label="ImpactX Bridge on LinkedIn"><i class="fab fa-linkedin-in"></i></a>
@@ -138,7 +137,6 @@
                     <a href="https://www.facebook.com/share/1XefZhW6ML/" target="_blank" aria-label="ImpactX Bridge on Facebook"><i class="fab fa-facebook-f"></i></a>
                     <a href="https://youtube.com/@impactxbridge?si=-VhFO5plG41Tcmoe" target="_blank" aria-label="ImpactX Bridge on YouTube"><i class="fab fa-youtube"></i></a>
                 </div>
-                -->
             </div>
             <div class="footer-logo-item">
                  <img src="/logowithname.png" alt="ImpactX Bridge - Full Logo" class="footer-full-logo-img">


### PR DESCRIPTION
- Re-added (uncommented) the social media icons in the footer across all relevant HTML pages.
- Verified that the CSS for centering these icons on mobile (`justify-content: center` on `.social-media-links` and `text-align: center` on parent `footer div`) is in place.
- Removed `!important` from `.chart-preview-images` as the general CSS parsing issue was resolved.