### PR TITLE
Style: Add !important to mobile footer social icon centering (diag)

### DIFF
--- a/style.css
+++ b/style.css
@@ -972,7 +972,7 @@ section:not(#hero) .container { /* Apply to sections that need centered content 
     }
     .social-media-links {
         display: flex; /* Ensure it's a flex container */
-        justify-content: center; /* Centers the icons within this flex container */
+        justify-content: center !important; /* Added !important for diagnostics. Centers the icons within this flex container */
         width: 100%; /* Make the container take full width to allow centering of its items */
     }
 }


### PR DESCRIPTION
Added `!important` to `justify-content: center` for `.social-media-links` in the mobile media query as a diagnostic step to determine if the left-alignment issue is due to CSS specificity.