### PR TITLE
Fix: Ensure list markers (bullets/numbers) are visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -63,6 +63,26 @@ ul, ol {
     padding-left: 1.5em;
 }
 
+/* Assertive list styling for content sections to ensure markers are visible */
+section .container ul,
+section .container ol {
+    list-style-position: inside !important; /* Force position */
+    padding-left: 1.5em !important; /* Force padding */
+    list-style-type: revert !important; /* Try to force default markers */
+}
+
+/* Specifically for the 'Our Infrastructure Includes' ordered list */
+#what-is-impactx ol {
+    list-style-type: decimal !important; /* Ensure numbers */
+}
+
+/* Specifically for 'Who We Serve' and lists in PAIP section that are ULs */
+#what-is-impactx ul,
+#what-is-paip ul { /* This will also cover lists in .solution-column within #what-is-paip */
+    list-style-type: disc !important; /* Ensure bullets */
+}
+
+
 blockquote {
     border-left: 4px solid #D32F2F; /* Red accent for blockquote */
     padding-left: 1em;


### PR DESCRIPTION
Added assertive CSS rules to style.css to explicitly define list-style-position, padding-left, and list-style-type for ul and ol elements within main content sections (#what-is-impactx, #what-is-paip).

Used `!important` as a diagnostic measure to override potential conflicting styles that were hiding the list markers. This addresses the issue of missing bullets and numbers in newly added lists.

Further refinement to remove `!important` may be considered later if the root cause of the original override is identified.