### PR TITLE
Feat: Embed YouTube explainer video on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,22 @@
             </div>
         </section>
 
+        <section id="impactx-video-explainer">
+            <div class="container">
+                <h2>Discover ImpactX Bridge in Action</h2>
+                <div class="video-wrapper">
+                    <iframe
+                        width="560" height="315"
+                        src="https://www.youtube.com/embed/eOqk_wHqT1Q"
+                        title="YouTube video player - ImpactX Bridge Explanation"
+                        frameborder="0"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        allowfullscreen>
+                    </iframe>
+                </div>
+            </div>
+        </section>
+
         <section id="why-now">
             <div class="container">
                 <h2>Why Now?</h2>

--- a/style.css
+++ b/style.css
@@ -1530,3 +1530,27 @@ section {
     The general .chart-preview-images rule defines display: flex; etc.
     The general mobile overrides will also apply to both.
 */
+
+/* Responsive Video Embed */
+#impactx-video-explainer {
+    text-align: center; /* Center the section title and video block */
+}
+
+.video-wrapper {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio (9 / 16 = 0.5625) */
+    height: 0;
+    overflow: hidden;
+    max-width: 800px; /* Max width for the video, can be adjusted */
+    margin: 20px auto; /* Center the video wrapper if it's narrower than container */
+    background-color: #000; /* Optional: background for letterboxing if aspect ratio doesn't match perfectly */
+}
+
+.video-wrapper iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0; /* Ensure no iframe border from browser defaults */
+}


### PR DESCRIPTION
- Added a new section after 'What is ImpactX Bridge?' to display an explainer video.
- Embedded the YouTube video (ID: eOqk_wHqT1Q) using an iframe.
- Added a title 'Discover ImpactX Bridge in Action' for the video section.
- Implemented CSS to make the video embed responsive, maintaining a 16:9 aspect ratio across different screen sizes.