### PR TITLE
Fix: Refine list styling to resolve conflict with #how-it-works

### DIFF
--- a/style.css
+++ b/style.css
@@ -71,44 +71,46 @@ blockquote {
     color: #555;
 }
 
-/* --- Global Manual List Styling for Content --- */
+/* --- Global Manual List Styling for Content (Excluding #how-it-works) --- */
 /* 1. Neutralize all lists within content sections */
-section .container ul,
-section .container ol {
+section:not(#how-it-works) .container ul,
+section:not(#how-it-works) .container ol {
     list-style: none;
     padding-left: 0;
 }
 
 /* 2. Give list items themselves the indentation */
-section .container li {
+section:not(#how-it-works) .container li {
     padding-left: 1.5em; /* Indent the text */
     position: relative; /* Needed for positioning the marker */
+    margin-bottom: 0.5em; /* Add some space between list items */
 }
 
 /* 3. Add manual markers for all ULs in content */
-section .container ul > li::before {
+section:not(#how-it-works) .container ul > li::before {
     content: '•';
     position: absolute;
-    left: 0;
+    left: 0.2em; /* Give a little space from the edge */
     top: 0;
     color: #D32F2F;
     font-weight: bold;
 }
 
 /* 4. Add manual markers for all OLs in content */
-section .container ol {
+section:not(#how-it-works) .container ol {
     counter-reset: list-counter;
 }
-section .container ol > li {
+section:not(#how-it-works) .container ol > li {
     counter-increment: list-counter;
 }
-section .container ol > li::before {
+section:not(#how-it-works) .container ol > li::before {
     content: counter(list-counter) ".";
     position: absolute;
     left: 0;
     top: 0;
     color: #D32F2F;
     font-weight: bold;
+    width: 1.5em; /* Give number space to not overlap text */
 }
 
 /* Utility Classes */


### PR DESCRIPTION
- Updated the global manual list marker CSS rules to exclude the `#how-it-works` section using the `:not()` pseudo-class.
- This prevents the global rules from conflicting with the section's own unique, pre-existing list styles, restoring its original appearance.
- Made minor spacing and alignment improvements to the global manual markers for better visual consistency.